### PR TITLE
Folder name overflow fix

### DIFF
--- a/livnote/frontend/desktop/components/layout/NavigationPanel.svelte
+++ b/livnote/frontend/desktop/components/layout/NavigationPanel.svelte
@@ -34,7 +34,7 @@
 
 {#if uiState.showNavigationPanel}
 	<nav
-		class="w-[17rem] shrink-0 h-full pt-4 pb-1 px-1 whitespace-nowrap relative border-r border-osvauld-borderColor flex flex-col"
+		class="w-[17rem] shrink-0 h-full pt-4 pb-1 px-1 relative border-r border-osvauld-borderColor flex flex-col"
 		aria-label="Main Navigation"
 	>
 		{#if uiState.noteViewLayout}

--- a/livnote/frontend/desktop/components/ui/AllNotesFolder.svelte
+++ b/livnote/frontend/desktop/components/ui/AllNotesFolder.svelte
@@ -29,16 +29,6 @@
 	const isSelected = $derived(dataState.currentVault.id === "all");
 </script>
 
-<style>
-	/* Ensure proper text truncation in flex containers */
-	.folder-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		max-width: 100%;
-	}
-</style>
-
 <div class="select-none">
 	<!-- All Notes folder header -->
 	<div
@@ -62,7 +52,7 @@
 
 			<!-- All Notes name -->
 			<span
-				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 folder-name"
+				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
 				title="All Notes"
 			>
 				All Notes

--- a/livnote/frontend/desktop/components/ui/AllNotesFolder.svelte
+++ b/livnote/frontend/desktop/components/ui/AllNotesFolder.svelte
@@ -29,6 +29,16 @@
 	const isSelected = $derived(dataState.currentVault.id === "all");
 </script>
 
+<style>
+	/* Ensure proper text truncation in flex containers */
+	.folder-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+</style>
+
 <div class="select-none">
 	<!-- All Notes folder header -->
 	<div
@@ -37,7 +47,7 @@
 			: 'text-osvauld-fieldText hover:text-osvauld-sideListTextActive hover:bg-osvauld-fieldActive'} rounded-lg px-2 py-3"
 	>
 		<div
-			class="flex-1 flex items-center gap-1.5 rounded-lg transition-colors duration-150"
+			class="flex-1 flex items-center gap-1.5 rounded-lg transition-colors duration-150 min-w-0"
 			role="treeitem"
 			aria-selected={isSelected}
 			tabindex="0"
@@ -52,7 +62,8 @@
 
 			<!-- All Notes name -->
 			<span
-				class="flex-1 truncate text-left text-sm font-light select-none cursor-default"
+				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 folder-name"
+				title="All Notes"
 			>
 				All Notes
 			</span>

--- a/livnote/frontend/desktop/components/ui/NoteListPanel.svelte
+++ b/livnote/frontend/desktop/components/ui/NoteListPanel.svelte
@@ -27,16 +27,6 @@
 	};
 </script>
 
-<style>
-	/* Ensure proper text truncation for folder title */
-	.folder-title {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		max-width: 100%;
-	}
-</style>
-
 <div class="py-3 pr-4 flex items-center justify-start shrink-0">
 	<!-- <div class="relative shrink-0">
 		<button
@@ -64,13 +54,13 @@
 	<div class="mr-auto flex items-center gap-6 text-base min-w-0 flex-1">
 		<!-- Current folder title -->
 		<div
-			class="text-[26px] text-osvauld-sideListTextActive font-light leading-6 capitalize min-w-0 max-w-full folder-title"
+			class="text-[26px] text-osvauld-sideListTextActive font-light leading-6 capitalize min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
 			aria-label="Current folder: {dataState.currentVault.id === 'all'
 				? 'All Notes'
 				: dataState.currentVault.name}"
-			title="{dataState.currentVault.id === 'all'
-				? 'All Notes'
-				: dataState.currentVault.name}"
+			title={dataState.currentVault.id === "all"
+				? "All Notes"
+				: dataState.currentVault.name}
 		>
 			{dataState.currentVault.id === "all"
 				? "All Notes"

--- a/livnote/frontend/desktop/components/ui/NoteListPanel.svelte
+++ b/livnote/frontend/desktop/components/ui/NoteListPanel.svelte
@@ -27,6 +27,16 @@
 	};
 </script>
 
+<style>
+	/* Ensure proper text truncation for folder title */
+	.folder-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+</style>
+
 <div class="py-3 pr-4 flex items-center justify-start shrink-0">
 	<!-- <div class="relative shrink-0">
 		<button
@@ -51,11 +61,14 @@
 			<FolderManager position="noteList" />
 		{/if}
 	</div> -->
-	<div class="mr-auto flex items-center gap-6 text-base">
+	<div class="mr-auto flex items-center gap-6 text-base min-w-0 flex-1">
 		<!-- Current folder title -->
 		<div
-			class="text-[26px] text-osvauld-sideListTextActive font-light leading-6 capitalize truncate"
+			class="text-[26px] text-osvauld-sideListTextActive font-light leading-6 capitalize min-w-0 max-w-full folder-title"
 			aria-label="Current folder: {dataState.currentVault.id === 'all'
+				? 'All Notes'
+				: dataState.currentVault.name}"
+			title="{dataState.currentVault.id === 'all'
 				? 'All Notes'
 				: dataState.currentVault.name}"
 		>

--- a/livnote/frontend/desktop/components/ui/TreeFolder.svelte
+++ b/livnote/frontend/desktop/components/ui/TreeFolder.svelte
@@ -165,6 +165,16 @@
 	});
 </script>
 
+<style>
+	/* Ensure proper text truncation in flex containers */
+	.folder-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+</style>
+
 <div class="select-none" style={indentStyle}>
 	<!-- Folder header -->
 	<div
@@ -173,7 +183,7 @@
 			: 'text-osvauld-fieldText hover:text-osvauld-sideListTextActive hover:bg-osvauld-fieldActive'} rounded-lg p-2"
 	>
 		<div
-			class="flex-1 flex items-center gap-1.5 rounded-lg transition-colors duration-150"
+			class="flex-1 flex items-center gap-1.5 rounded-lg transition-colors duration-150 min-w-0"
 			role="treeitem"
 			aria-expanded={folder.id !== "all" ? isExpanded : undefined}
 			aria-selected={isSelected}
@@ -209,7 +219,8 @@
 
 			<!-- Folder name -->
 			<span
-				class="flex-1 truncate text-left text-sm font-light select-none cursor-default"
+				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 folder-name"
+				title="{folder.id === 'all' ? 'All Notes' : folder.name}"
 			>
 				{folder.id === "all" ? "All Notes" : folder.name}
 			</span>

--- a/livnote/frontend/desktop/components/ui/TreeFolder.svelte
+++ b/livnote/frontend/desktop/components/ui/TreeFolder.svelte
@@ -165,16 +165,6 @@
 	});
 </script>
 
-<style>
-	/* Ensure proper text truncation in flex containers */
-	.folder-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		max-width: 100%;
-	}
-</style>
-
 <div class="select-none" style={indentStyle}>
 	<!-- Folder header -->
 	<div
@@ -219,8 +209,8 @@
 
 			<!-- Folder name -->
 			<span
-				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 folder-name"
-				title="{folder.id === 'all' ? 'All Notes' : folder.name}"
+				class="flex-1 text-left text-sm font-light select-none cursor-default min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
+				title={folder.id === "all" ? "All Notes" : folder.name}
 			>
 				{folder.id === "all" ? "All Notes" : folder.name}
 			</span>

--- a/livnote/frontend/desktop/components/ui/TreeNote.svelte
+++ b/livnote/frontend/desktop/components/ui/TreeNote.svelte
@@ -31,9 +31,19 @@
 	const isActiveState = $derived(isSelected || isHovered);
 </script>
 
+<style>
+	/* Ensure proper text truncation in flex containers */
+	.note-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+</style>
+
 <div class="pl-1.5 my-1">
 	<button
-		class="w-full flex items-center gap-3 p-2.5 rounded-lg transition-colors duration-150
+		class="w-full flex items-center gap-3 p-2.5 rounded-lg transition-colors duration-150 min-w-0
 			{isActiveState
 			? 'text-osvauld-sideListTextActive bg-osvauld-fieldActive'
 			: 'text-osvauld-fieldText hover:text-osvauld-sideListTextActive hover:bg-osvauld-fieldActive'}"
@@ -55,7 +65,10 @@
 		</span>
 
 		<!-- Note title -->
-		<span class="flex-1 truncate text-left text-sm font-light">
+		<span 
+			class="flex-1 text-left text-sm font-light min-w-0 note-title"
+			title="{note.title || 'Untitled'}"
+		>
 			{note.title || "Untitled"}
 		</span>
 

--- a/livnote/frontend/desktop/components/ui/TreeNote.svelte
+++ b/livnote/frontend/desktop/components/ui/TreeNote.svelte
@@ -31,16 +31,6 @@
 	const isActiveState = $derived(isSelected || isHovered);
 </script>
 
-<style>
-	/* Ensure proper text truncation in flex containers */
-	.note-title {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		max-width: 100%;
-	}
-</style>
-
 <div class="pl-1.5 my-1">
 	<button
 		class="w-full flex items-center gap-3 p-2.5 rounded-lg transition-colors duration-150 min-w-0
@@ -65,9 +55,9 @@
 		</span>
 
 		<!-- Note title -->
-		<span 
-			class="flex-1 text-left text-sm font-light min-w-0 note-title"
-			title="{note.title || 'Untitled'}"
+		<span
+			class="flex-1 text-left text-sm font-light min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
+			title={note.title || "Untitled"}
 		>
 			{note.title || "Untitled"}
 		</span>

--- a/livnote/frontend/desktop/state/ui.svelte.ts
+++ b/livnote/frontend/desktop/state/ui.svelte.ts
@@ -139,6 +139,15 @@ class UIState {
     } else {
       this.noteViewLayout = !this.noteViewLayout;
     }
+    
+    // When switching back to folder view (noteViewLayout = false), 
+    // automatically show the navigation panel and reset manual toggle state
+    if (!this.noteViewLayout) {
+      this.showNavigationPanel = true;
+      this.isNavigationPanelManuallyToggled = false;
+      // Reset the CSS custom property for editor width
+      document.documentElement.style.setProperty("--min-editor-width", "900px");
+    }
   }
 
   toggleProfileViewLayout(show?: boolean) {

--- a/livnote/frontend/desktop/state/ui.svelte.ts
+++ b/livnote/frontend/desktop/state/ui.svelte.ts
@@ -146,7 +146,7 @@ class UIState {
       this.showNavigationPanel = true;
       this.isNavigationPanelManuallyToggled = false;
       // Reset the CSS custom property for editor width
-      document.documentElement.style.setProperty("--min-editor-width", "900px");
+      document.documentElement.style.setProperty("--min-editor-width", `${this.MIN_EDITOR_WIDTH}px`);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "@osvauld/workspace",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@osvauld/workspace",
+      "version": "0.0.1",
+      "devDependencies": {
+        "pnpm": "^9.15.9"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "9.15.9",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz",
+      "integrity": "sha512-aARhQYk8ZvrQHAeSMRKOmvuJ74fiaR1p5NQO7iKJiClf1GghgbrlW1hBjDolO95lpQXsfF+UA+zlzDzTfc8lMQ==",
+      "dev": true,
+      "bin": {
+        "pnpm": "bin/pnpm.cjs",
+        "pnpx": "bin/pnpx.cjs"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "dev:libremot": "pnpm --filter @osvauld/libremot dev"
   },
   "devDependencies": {
-    "pnpm": "^9.0.0"
+    "pnpm": "^9.15.9"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text handling: long folder and note titles now truncate with ellipsis and respect flex layouts.
  * Added hover/tooltips showing full titles for folders and notes (including “All Notes”).
  * Navigation now allows line-wrapping to improve layout on narrow widths.

* **Bug Fixes**
  * Fixed text overflow/clipping in folder tree, All Notes item, note list, and current folder header.
  * Switching to folder view now auto-opens the navigation panel and resets editor width for proper layout.

* **Chores**
  * Updated development tooling (pnpm dev dependency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->