### PR TITLE
note switching in tree folder fix

### DIFF
--- a/livnote/frontend/desktop/components/layout/HeaderSection.svelte
+++ b/livnote/frontend/desktop/components/layout/HeaderSection.svelte
@@ -89,13 +89,9 @@
 		dataState.setSearchResults(noteIds);
 	};
 
-	// Home button handler - saves and returns to list view
+	// Home button handler - returns to list view
 	const handleHomeButton = () => {
-		const noteId = dataState.currentNoteId;
-		if (noteId) {
-			dataState.saveNote(noteId);
-			dataState.switchNote(null);
-		}
+		dataState.switchNote(null);
 		uiState.toggleNoteRightPanel(true);
 		uiState.toggleNoteViewLayout(false);
 		uiState.toggleProfileViewLayout(false);

--- a/livnote/frontend/desktop/components/layout/NotesWorkspace.svelte
+++ b/livnote/frontend/desktop/components/layout/NotesWorkspace.svelte
@@ -88,13 +88,9 @@
 		}
 	}
 
-	// Back button handler - saves and returns to list view
+	// Back button handler - returns to list view
 	const handleBackButton = () => {
-		const noteId = dataState.currentNoteId;
-		if (noteId) {
-			dataState.saveNote(noteId);
-			dataState.switchNote(null);
-		}
+		dataState.switchNote(null);
 		uiState.toggleNoteRightPanel(true);
 		uiState.toggleNoteViewLayout(false);
 	};

--- a/livnote/frontend/desktop/state/data.svelte.ts
+++ b/livnote/frontend/desktop/state/data.svelte.ts
@@ -153,6 +153,14 @@ class DataState {
   }
 
   async switchVault(vault: Vault) {
+    // Save the current note if one is open (non-blocking)
+    const currentNoteId = this.currentNoteId;
+    if (currentNoteId) {
+      this.saveNote(currentNoteId).catch(error => {
+        console.error("Error saving note before switching vault:", error);
+      });
+    }
+
     this.currentVault = vault;
     StoreService.setCurrentVault(vault);
     uiState.toggleNoteViewLayout(false);

--- a/livnote/frontend/desktop/state/data.svelte.ts
+++ b/livnote/frontend/desktop/state/data.svelte.ts
@@ -202,6 +202,15 @@ class DataState {
   }
 
   async switchNote(noteId: string | null) {
+    // Save the current note before switching away from it (non-blocking)
+    const currentNoteId = this.currentNoteId;
+    if (currentNoteId && currentNoteId !== noteId) {
+      // Fire and forget - save in background without blocking the switch
+      this.saveNote(currentNoteId).catch(error => {
+        console.error("Error saving note before switching:", error);
+      });
+    }
+
     emit("note-change", noteId
     ).catch(error => {
       uiState.clearAllLoadingStates();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Navigation to Home and back to the notes list is now faster; the app no longer pauses to save before leaving the editor.
  - When switching notes, your current note is automatically saved in the background, preserving changes without interrupting your workflow.
  - Overall note switching and view transitions feel more responsive while maintaining data safety through non-blocking auto-save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->