### PR TITLE
Osvauld/share folder bug

### DIFF
--- a/crypto_utils/src/crypto_utils.rs
+++ b/crypto_utils/src/crypto_utils.rs
@@ -404,7 +404,6 @@ impl CryptoUtils {
         folder_id: &str,
         recipient_ucan_pub_key: &str,
         permissions_to_grant: Vec<(String, String)>,
-        capability_prefix: &str,
         proof_resolver: &F,
     ) -> Result<(String, String), CryptoError>
     where
@@ -414,8 +413,12 @@ impl CryptoUtils {
         // 1. Validate the proof folder UCAN structure
         let folder_ucan_to_prove = ucan_utils::validate_structure(proof_folder_ucan_string).await?;
 
-        // 2. Validate the user has permission to share this folder
-        let folder_resource = format!("{}:folder:{}", capability_prefix, folder_id);
+        // 2. Extract domain from the parent UCAN's capabilities
+        let domain = ucan_utils::extract_domain_from_ucan(&folder_ucan_to_prove, "folder")?;
+        
+        // 3. Construct the full folder URI for validation
+        let folder_resource = format!("{}:folder:{}", domain, folder_id);
+        
         ucan_utils::validate_ucan_permission(
             &folder_ucan_to_prove,
             verifier_ucan_pub_b64,
@@ -425,11 +428,11 @@ impl CryptoUtils {
         )
         .await?;
 
-        // 3. Decrypt the delegator's UCAN keys
+        // 4. Decrypt the delegator's UCAN keys
         let (delegator_signing_key, delegator_verifying_key) =
             self.decrypt_ucan_key(encrypted_delegator_private_key)?;
 
-        // 4. Generate the delegated UCAN using existing function
+        // 5. Generate the delegated UCAN using existing function
         let (new_token, new_cid) = ucan_utils::generate_delegated_ucan(
             &delegator_signing_key,
             &delegator_verifying_key,
@@ -459,11 +462,17 @@ impl CryptoUtils {
     {
         let ucan_to_prove = ucan_utils::validate_structure(proof_ucan_string).await?;
 
+        // Extract domain from the parent UCAN's capabilities
+        let domain = ucan_utils::extract_domain_from_ucan(&ucan_to_prove, "resource")?;
+        
+        // Construct the full resource URI for validation
+        let resource_uri = format!("{}:resource:{}", domain, resource_id);
+
         ucan_utils::validate_ucan_permission(
             &ucan_to_prove,
             verifier_ucan_pub_b64,
             proof_resolver,
-            resource_id,
+            &resource_uri,
             &"ucan/share".to_string(),
         )
         .await?;

--- a/crypto_utils/src/ucan_utils.rs
+++ b/crypto_utils/src/ucan_utils.rs
@@ -378,6 +378,35 @@ pub fn check_capability(
     Err(UcanError::CapabilityNotFound)
 }
 
+/// Extract the domain prefix from a UCAN's capabilities.
+///
+/// This function looks for resource or folder capabilities in the UCAN and extracts
+/// the domain prefix (e.g., "livnote" from "livnote:resource:abc123").
+///
+/// ### Arguments
+/// * `ucan` - The UCAN object to extract the domain from.
+/// * `resource_type` - The type of resource to look for ("resource" or "folder").
+///
+/// ### Returns
+/// The domain prefix string, or an error if no matching capability is found.
+pub fn extract_domain_from_ucan(ucan: &Ucan, resource_type: &str) -> Result<String, UcanError> {
+    for capability in ucan.capabilities().iter() {
+        let cap_resource = capability.resource;
+        
+        // Look for the resource_type pattern in the URI
+        // Format: "domain:resource_type:id" or "domain:resource_type:*"
+        if let Some(middle_pos) = cap_resource.find(&format!(":{}", resource_type)) {
+            // Extract everything before ":resource_type"
+            let domain = &cap_resource[..middle_pos];
+            if !domain.is_empty() {
+                return Ok(domain.to_string());
+            }
+        }
+    }
+    
+    Err(UcanError::CapabilityNotFound)
+}
+
 fn pub_key_b64_to_did(key_b64: &str) -> Result<String, UcanError> {
     let key_bytes = general_purpose::STANDARD
         .decode(key_b64)

--- a/services/src/folder_service.rs
+++ b/services/src/folder_service.rs
@@ -117,6 +117,16 @@ pub async fn share_folder(
     // Get encrypted UCAN private key
     let encrypted_ucan_key = repo_ctx.store_repo.get_ucan_key().await?;
 
+    // Find the folder owner (root authority) from self-share record
+    let folder_owner_id = existing_folder_shares
+        .iter()
+        .find(|share| share.shared_by_user_id == share.recipient_user_id)
+        .ok_or(FolderServiceError::InsufficientPermissions)?
+        .recipient_user_id
+        .clone();
+
+    let folder_owner = repo_ctx.user_repo.get_user_by_id(&folder_owner_id).await?;
+
     // Create proof resolver for folder UCAN validation
     let repo_ctx_clone = repo_ctx.clone();
     let proof_resolver = move |cid: &str| resolve_proof(repo_ctx_clone.clone(), cid.to_string());
@@ -128,7 +138,7 @@ pub async fn share_folder(
             .issue_delegated_folder_ucan(
                 &encrypted_ucan_key,
                 &user_folder_ucan_token,
-                &current_user.ucan_pub_key,
+                &folder_owner.ucan_pub_key,
                 folder_id,
                 &repo_ctx
                     .user_repo

--- a/services/src/folder_service.rs
+++ b/services/src/folder_service.rs
@@ -136,7 +136,6 @@ pub async fn share_folder(
                     .await?
                     .ucan_pub_key,
                 folder_permissions,
-                domain,
                 &proof_resolver,
             )
             .await?

--- a/services/src/resource_service.rs
+++ b/services/src/resource_service.rs
@@ -339,7 +339,13 @@ pub async fn prepare_share_resource(
 
     let encrypted_ucan_pvt_key = repo_ctx.store_repo.get_ucan_key().await?;
 
-    // 6. Create the signature for the share record
+    // 6. Get the resource owner (root authority for validation)
+    let resource_owner = repo_ctx
+        .resource_repo
+        .find_owner_by_resource_id(resource_id)
+        .await?;
+
+    // 7. Create the signature for the share record
     let repo_ctx_clone = repo_ctx.clone();
     let proof_resolver = move |cid: &str| resolve_proof(repo_ctx_clone.clone(), cid.to_string());
 
@@ -349,7 +355,7 @@ pub async fn prepare_share_resource(
             .issue_delegated_resource_ucan(
                 &encrypted_ucan_pvt_key,
                 &delegator_share_record.ucan_token,
-                &current_user.ucan_pub_key,
+                &resource_owner.ucan_pub_key,
                 resource_id,
                 &recipient_user.ucan_pub_key,
                 permissions,
@@ -358,7 +364,7 @@ pub async fn prepare_share_resource(
             .await?
     };
 
-    // 7. Create the share record
+    // 8. Create the share record
     let share_record = ShareRecord::prepare_share_record(
         resource_id.to_string(),
         current_user.id.to_string(),
@@ -368,7 +374,7 @@ pub async fn prepare_share_resource(
         ucan_cid,
     );
 
-    // 8. Get recipient's devices to create vector clocks
+    // 9. Get recipient's devices to create vector clocks
     let recipient_devices = repo_ctx
         .device_repo
         .get_devices_by_user_id(recipient_user_id)
@@ -377,7 +383,7 @@ pub async fn prepare_share_resource(
     let recipient_device_ids: Vec<String> =
         recipient_devices.iter().map(|d| d.id.clone()).collect();
 
-    // 9. Create vector clocks for recipient's devices
+    // 10. Create vector clocks for recipient's devices
     let recipient_vector_clocks =
         ResourceVectorClock::create_entries_for_sharing(resource_id, &recipient_device_ids);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected folder and resource sharing to use the actual owner’s key, preventing failed or incorrect delegations.
  * Resolved permission mismatches by validating access against domain-scoped resources, reducing share/permission errors.

* **Refactor**
  * Standardized delegation to derive domains automatically from existing tokens, simplifying and hardening access checks.
  * Centralized domain-aware resource handling across folder and resource sharing flows for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->